### PR TITLE
Add support for controlling OpenSSL's FIPS 140-2 module

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2020-01-27  Shaun Lowry <shaunl@activestate.com>
+
+    * configure.ac: add --enable-fips-control
+	* tls.c: add FIPS_mode and FIPS_mode_set commands
+	* tls.htm: add documentation on FIPS_mode and FIPS_mode_set commands
+
 2015-05-01  Andreas Kupries  <andreask@activestate.com>
 
 	* configure.in: Bump to version 1.6.5.

--- a/README.txt
+++ b/README.txt
@@ -25,6 +25,7 @@ Non-exclusive credits for TLS are:
    Original work: Matt Newman @ Novadigm
    Updates: Jeff Hobbs @ ActiveState
    Tcl Channel mechanism: Andreas Kupries
+   FIPS 140-2 module control: Shaun Lowry @ ActiveState
    Impetus/Related work: tclSSL (Colin McCormack, Shared Technology)
                          SSLtcl (Peter Antman)
 

--- a/configure.ac
+++ b/configure.ac
@@ -216,6 +216,21 @@ if test "$tcltls_ssl_lib" = "libressl"; then
 	tcltls_ssl_lib='openssl'
 fi
 
+dnl Enable OpenSSL FIPS mode control
+tcltls_enable_fips_control='no'
+AC_ARG_ENABLE([fips-control], AS_HELP_STRING([--enable-fips-control], [enable control of the OpenSSL FIPS module]), [
+	if test "$enableval" = 'yes'; then
+		tcltls_enable_fips_control='yes'
+	else
+		tcltls_enable_fips_control='no'
+	fi
+    if test "$tcltls_enable_fips_control" = 'yes'; then
+        if test "$tcltls_ssl_lib" = 'openssl'; then
+            AC_DEFINE([OPENSSL_FIPS], [1], [Enable FIPS mode control])
+        fi
+    fi
+])
+
 AS_CASE([$tcltls_ssl_lib],
 	[openssl], [
 		TCLTLS_SSL_OPENSSL

--- a/tls.htm
+++ b/tls.htm
@@ -32,6 +32,8 @@ content="text/html; charset=iso-8859-1">
             <dd><b>tls::unimport</b><em> channel</em></dd>
             <dd><b>tls::ciphers </b><em>protocol ?verbose?</em></dd>
             <dd><b>tls::version</b></dd>
+            <dd><b>tls::FIPS_mode_set </b><em>mode</em></dd>
+            <dd><b>tls::FIPS_mode</b></dd>
         </dl>
     </dd>
     <dd><a href="#COMMANDS">COMMANDS</a></dd>
@@ -54,6 +56,7 @@ toolkit.</p>
 <b>package require tls @@VERS@@</b><br>
 <br>
 <a href="#tls::init"><b>tls::init </b><i>?options?</i><br>
+<a href="#tls::FIPS_mode_set"><b>tls::FIPS_mode_set </b><i>mode</i><br>
 </a><a href="#tls::socket"><b>tls::socket </b><em>?options? host
 port</em><br>
 <b>tls::socket</b><em> ?-server command? ?options? port</em><br>
@@ -249,6 +252,22 @@ used directly.</p>
 <dl>
     <dt><a name="tls::version"><strong>tls::version</strong></a></dt>
     <dd>Returns the version string defined by OpenSSL.</dd>
+</dl>
+
+<dl>
+    <dt><a name="tls::FIPS_mode"><strong>tls::FIPS_mode</strong></a></dt>
+    <dd>If compiled with the optional FIPS 140-2 control and the OpenSSL
+    FIPS 140-2 module is available, returns the status of the FIPS module.
+    1 for active, 0 for inactive.</dd>
+</dl>
+
+<dl>
+    <dt><a name="tls::FIPS_mode_set"><strong>tls::FIPS_mode_set</strong>
+        <em>mode</em></a></dt>
+    <dd>If compiled with the optional FIPS 140-2 control and the OpenSSL
+    FIPS 140-2 module is available, sets the status of the FIPS module.
+    1 for active, 0 for inactive.  Returns the current mode if successful,
+    throws an error on failure.</dd>
 </dl>
 
 <h3><a name="CALLBACK OPTIONS">CALLBACK OPTIONS</a></h3>


### PR DESCRIPTION
Adds the tls::FIPS_mode and tls::FIPS_mode_set commands to the module
which query and set the operation of OpenSSL's FIPS 140-2 module
respectively.  These are conditionally compiled in on the OPENSSL_FIPS
macro which is enabled through a new configure flag,
--enable-fips-control

The commands simply expose the underlying FIPS_mode and FIPS_mode_set
C routines from the OpenSSL library.